### PR TITLE
TypeError: Cannot read property '1' of null

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,7 +12,7 @@ module.exports = function(config) {
         colors: true,
         logLevel: config.LOG_INFO,
         autoWatch: true,
-        browsers: ['Firefox'],
+        browsers: ['Firefox','Chrome'],
         singleRun: true,
         preprocessors: {
             'src/*.js': ['browserify'],

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.21",
     "karma-browserify": "^5.0.1",
+    "karma-chrome-launcher": "^2.0.0",
     "karma-firefox-launcher": "^0.1.6",
     "karma-jasmine": "^0.3.7",
     "karma-spec-reporter": "0.0.20",

--- a/src/detect-font.js
+++ b/src/detect-font.js
@@ -22,7 +22,8 @@ const BASE_FONTS = ['sans-serif', 'serif', 'monospace'];
  * @return {String}
  */
 export const removeQuotes = name => {
-    return String(name).match(/^["']?(.+?)["']?$/i)[1];
+    let matches = String(name).match(/^["']?(.+?)["']?$/i);
+    return Array.isArray(matches)?matches[1]:'';
 };
 
 /**

--- a/tests/detect-font.test.js
+++ b/tests/detect-font.test.js
@@ -50,6 +50,12 @@ describe('DetectFont:', () => {
             expect(supportedFonts(node)).toEqual(['Times New Roman', 'Arial', 'monospace', 'Tahoma']);
         });
 
+
+        it('Should return an empty array', () => {
+            node.style.fontFamily = '"test fontName"';
+            expect(supportedFonts(node)).toEqual([]);
+        });
+
         it('Should be case-insensitive;', () => {
             node.style.fontFamily = 'ARIAL, TAHOMA, HELVETICA';
             expect(detectFont(node)).toEqual('ARIAL');


### PR DESCRIPTION
 -  fix match return null in chrome 
```
TypeError: Cannot read property '1' of null
```
- added should return an empty array in test

